### PR TITLE
Increase max_connect_errors to avoid timeouts triggered by health checks

### DIFF
--- a/templates/etc/mysql/my.cnf
+++ b/templates/etc/mysql/my.cnf
@@ -33,6 +33,7 @@ log_error = /var/log/mysql/error.log
 
 expire_logs_days = 10
 max_binlog_size = 100M
+max_connect_errors = 10512000  # At 2 failed connections per minute, this is 10 years.
 
 [mysqldump]
 quick

--- a/test/mysql.bats
+++ b/test/mysql.bats
@@ -21,3 +21,13 @@ teardown() {
 @test "It should require SSL" {
   skip
 }
+
+@test "It should set max_connect_errors to a large value" {
+# Containers from this Docker image are often run behind load balancers that
+# ping them constantly with TCP health checks, which can confuse MySQL because
+# they appear to be repeated failed connection attempts from the same host.
+# MySQL will eventually block connections from the load balancer if
+# max_connect_errors isn't set high enough.
+  run bash -c 'mysql -Ee "show variables where variable_name = \"max_connect_errors\"" | grep -oP "Value: \K([[:digit:]]+)"'
+  [[ "$output" -ge 10000000 ]]
+}


### PR DESCRIPTION
When behind load balancers like AWS ELBs, the MySQL server will get hit by TCP health checks. These health checks look like partial connection attempts to MySQL, so MySQL blocks the host trying to connect (which is the load balancer) after max_connect_errors. Since this Docker image isn't meant to allow arbitrary hosts to connect (either an ELB will be connecting or a small finite set of app instances behind inside a VPC will be connecting), I don't think we need the protection of max_connect_errors. Instead, we should set it to a high value (the value set here would allow for 10 years of health checks every 30 seconds) so that we actually get the benefit of health checks without the possibility of a blocked internal app or load balancer.

I can patch this onto the "standardized" branch as well if nobody objects to the patch.