### PR TITLE
Fix build of standardized image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM quay.io/aptible/debian:wheezy
 # cf. docker-library/mysql: explicitly create the user so uid and gid are consistent.
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
+ENV MYSQL_VERSION 5.6.24-1debian7
 ADD templates/etc/apt/sources.list.d /etc/apt/sources.list.d
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5 && \
     apt-get update && \
@@ -10,8 +11,8 @@ RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys A4A9406876FCBD3C
         netcat \
         perl \
         procps \
-        mysql-server=5.6.23-1debian7 \
-        mysql-client=5.6.23-1debian7 \
+        mysql-server=$MYSQL_VERSION \
+        mysql-client=$MYSQL_VERSION \
         && \
     rm -rf /var/lib/apt/lists/*
 
@@ -21,9 +22,9 @@ ENV DATA_DIRECTORY /var/db
 RUN mkdir -p "$DATA_DIRECTORY" && chown -R mysql:mysql "$DATA_DIRECTORY"
 
 ADD test /tmp/test
-# The current tests are simple. If they need mysqld running in the future, see
-# aptible/docker-postgresql for an example.
-RUN bats /tmp/test
+RUN mysql_install_db --user=mysql -ldata="$DATA_DIRECTORY" && \
+    bats /tmp/test && \
+    rm -rf "$DATA_DIRECTORY"/*
 
 VOLUME ["$DATA_DIRECTORY"]
 EXPOSE 3306

--- a/test/mysql.bats
+++ b/test/mysql.bats
@@ -27,6 +27,6 @@ teardown() {
 # they appear to be repeated failed connection attempts from the same host.
 # MySQL will eventually block connections from the load balancer if
 # max_connect_errors isn't set high enough.
-  run bash -c 'mysql -Ee "show variables where variable_name = \"max_connect_errors\"" | grep -oP "Value: \K([[:digit:]]+)"'
-  [[ "$output" -ge 10000000 ]]
+  max_connect_errors=$(mysql -Ee "show variables where variable_name = 'max_connect_errors'" | grep Value | awk '{ print $2 }')
+  [[ "$max_connect_errors" -ge 10000000 ]]
 }


### PR DESCRIPTION
This fixes a couple of issues that were breaking the build of the standardized image:

* MySQL 5.6.23 no longer in the package repository -- switching to 5.6.24.
* New test for `max_connect_errors` needs `mysqld` running but it wasn't running (successfully).
* `grep -P` needs a perl regex extension (`pcre`) installed. I just used `awk` in its place.