### PR TITLE
Add --client, --dump, --restore and --readonly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,5 @@ VOLUME ["$DATA_DIRECTORY"]
 EXPOSE 3306
 
 ADD run-database.sh /usr/bin/
+ADD utilities.sh /usr/bin/
 ENTRYPOINT ["run-database.sh"]

--- a/run-database.sh
+++ b/run-database.sh
@@ -10,24 +10,25 @@ if [[ "$1" == "--initialize" ]]; then
   service mysql start
   until nc -z localhost 3306; do sleep 0.1; done
 
+  mysql -e "GRANT ALL ON *.* to 'root'@'%' IDENTIFIED BY '$PASSPHRASE'"
   mysql -e "GRANT ALL ON ${DATABASE:-db}.* to '${USERNAME:-aptible}'@'%' IDENTIFIED BY '$PASSPHRASE'"
   mysql -e "CREATE DATABASE ${DATABASE:-db}"
   service mysql stop
 
 elif [[ "$1" == "--client" ]]; then
   [ -z "$2" ] && echo "docker run -it aptible/mysql --client mysql://..." && exit
-  password=$(extract_password_from_url "$2")
-  MYSQL_PWD="$password" mysql $(parse_url_into_cli_option_string "$2")
+  parse_url "$2"
+  MYSQL_PWD="$password" mysql --host="$host" --port="$port" --user="$user" "$database"
 
 elif [[ "$1" == "--dump" ]]; then
   [ -z "$2" ] && echo "docker run aptible/mysql --dump mysql://... > dump.sql" && exit
-  password=$(extract_password_from_url "$2")
-  MYSQL_PWD="$password" mysqldump $(parse_url_into_cli_option_string "$2")
+  parse_url "$2"
+  MYSQL_PWD="$password" mysqldump --host="$host" --port="$port" --user="$user" "$database"
 
 elif [[ "$1" == "--restore" ]]; then
   [ -z "$2" ] && echo "docker run -i aptible/mysql --restore mysql://... < dump.sql" && exit
-  password=$(extract_password_from_url "$2")
-  MYSQL_PWD="$password" mysql $(parse_url_into_cli_option_string "$2")
+  parse_url "$2"
+  MYSQL_PWD="$password" mysql --host="$host" --port="$port" --user="$user" "$database"
 
 elif [[ "$1" == "--readonly" ]]; then
   echo "Starting MySQL in read-only mode..."

--- a/run-database.sh
+++ b/run-database.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+. /usr/bin/utilities.sh
+
 if [[ "$1" == "--initialize" ]]; then
   chown -R mysql:mysql "$DATA_DIRECTORY"
 
@@ -8,10 +10,30 @@ if [[ "$1" == "--initialize" ]]; then
   service mysql start
   until nc -z localhost 3306; do sleep 0.1; done
 
-  mysql -e "GRANT ALL ON *.* to '${USERNAME:-aptible}'@'%' IDENTIFIED BY '$PASSPHRASE'"
+  mysql -e "GRANT ALL ON ${DATABASE:-db}.* to '${USERNAME:-aptible}'@'%' IDENTIFIED BY '$PASSPHRASE'"
   mysql -e "CREATE DATABASE ${DATABASE:-db}"
   service mysql stop
-  exit
-fi
 
-mysqld_safe
+elif [[ "$1" == "--client" ]]; then
+  [ -z "$2" ] && echo "docker run -it aptible/mysql --client mysql://..." && exit
+  password=$(extract_password_from_url "$2")
+  MYSQL_PWD="$password" mysql $(parse_url_into_cli_option_string "$2")
+
+elif [[ "$1" == "--dump" ]]; then
+  [ -z "$2" ] && echo "docker run aptible/mysql --dump mysql://... > dump.sql" && exit
+  password=$(extract_password_from_url "$2")
+  MYSQL_PWD="$password" mysqldump $(parse_url_into_cli_option_string "$2")
+
+elif [[ "$1" == "--restore" ]]; then
+  [ -z "$2" ] && echo "docker run -i aptible/mysql --restore mysql://... < dump.sql" && exit
+  password=$(extract_password_from_url "$2")
+  MYSQL_PWD="$password" mysql $(parse_url_into_cli_option_string "$2")
+
+elif [[ "$1" == "--readonly" ]]; then
+  echo "Starting MySQL in read-only mode..."
+  mysqld_safe --read-only
+
+else
+  mysqld_safe
+
+fi

--- a/utilities.sh
+++ b/utilities.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+parse_url_into_cli_option_string()
+{
+  # cf http://stackoverflow.com/a/17287984
+  protocol="$(echo "$1" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+  # remove the protocol
+  url=$(echo $1 | sed -e s,$protocol,,g)
+  # extract the user and password (if any)
+  user_and_password="$(echo $url | grep @ | cut -d@ -f1)"
+  password="$(echo $user_and_password | grep : | cut -d: -f2)"
+  if [ -n "$password" ]; then
+    user="$(echo $user_and_password | grep : | cut -d: -f1)"
+  else
+    user="$user_and_password"
+  fi
+
+  # extract the host
+  host_and_port="$(echo $url | sed -e s,$user_and_password@,,g | cut -d/ -f1)"
+  port="$(echo $host_and_port | grep : | cut -d: -f2)"
+  if [ -n "$port" ]; then
+    host="$(echo $host_and_port | grep : | cut -d: -f1)"
+  else
+    host="$host_and_port"
+  fi
+
+  database="$(echo $url | grep / | cut -d/ -f2-)"
+
+  options="-h "$host""
+  [ -n "$port" ] && options="$options -P "$port""
+  [ -n "$user" ] && options="$options --user="$user""
+  [ -n "$database" ] && options="$options $database"
+  echo $options
+}
+
+# Note that supplying the password with `--password=...` results in:
+# "Warning: Using a password on the command line interface can be insecure."
+# However, providing the environment variable `$MYSQL_PWD` suppresses the
+# warning. Hence the password extraction is separated here.
+extract_password_from_url()
+{
+  # cf http://stackoverflow.com/a/17287984
+  protocol="$(echo "$1" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+  # remove the protocol
+  url=$(echo $1 | sed -e s,$protocol,,g)
+  # extract the user and password (if any)
+  user_and_password="$(echo $url | grep @ | cut -d@ -f1)"
+  password="$(echo $user_and_password | grep : | cut -d: -f2)"
+  echo $password
+}

--- a/utilities.sh
+++ b/utilities.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-parse_url_into_cli_option_string()
+parse_url()
 {
   # cf http://stackoverflow.com/a/17287984
   protocol="$(echo "$1" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
@@ -25,26 +25,4 @@ parse_url_into_cli_option_string()
   fi
 
   database="$(echo $url | grep / | cut -d/ -f2-)"
-
-  options="-h "$host""
-  [ -n "$port" ] && options="$options -P "$port""
-  [ -n "$user" ] && options="$options --user="$user""
-  [ -n "$database" ] && options="$options $database"
-  echo $options
-}
-
-# Note that supplying the password with `--password=...` results in:
-# "Warning: Using a password on the command line interface can be insecure."
-# However, providing the environment variable `$MYSQL_PWD` suppresses the
-# warning. Hence the password extraction is separated here.
-extract_password_from_url()
-{
-  # cf http://stackoverflow.com/a/17287984
-  protocol="$(echo "$1" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
-  # remove the protocol
-  url=$(echo $1 | sed -e s,$protocol,,g)
-  # extract the user and password (if any)
-  user_and_password="$(echo $url | grep @ | cut -d@ -f1)"
-  password="$(echo $user_and_password | grep : | cut -d: -f2)"
-  echo $password
 }


### PR DESCRIPTION
Similar to the [postgres PR](https://github.com/aptible/docker-postgresql/pull/12), with some MySQL-specific notes:

* The MySQL client doesn't support specifying a connection string URL, but it should be supported here (1) for consistency across database images and (2) because it's a nice, compact way to specify the connection details. I cribbed a script from Stack Overflow to parse the URL into its pieces, but it's pretty ugly. That's `utilities.sh`.

* The MySQL client has a honeypot option `--password` which throws up
    ```
    Warning: Using a password on the command line interface can be insecure.
    ```
That actually gets printed during `mysqldump`, creating an invalid dump file if one redirects output `> dump.sql`. However, the client doesn't complain if you specify an environment variable `$MYSQL_PWD` instead. Much more secure.

* For super users, MySQL's read only mode has no effect at all. `GRANT ALL ON *.*` (currently in the initialization step) creates a super user while `GRANT ALL ON db.*` does not. I made that switch, but any databases already initialized from this image will not really be read only. Should the user be a super user?

* `utilities.sh` is rough. Any thoughts on alternate approaches, especially for sharing that sort of functionality across the various "standardized" database repositories?

@fancyremarker @aaw 