### PR TITLE
Adding SSL support

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -24,11 +24,9 @@ RUN mkdir -p "$DATA_DIRECTORY" && chown -R mysql:mysql "$DATA_DIRECTORY"
 
 ADD run-database.sh /usr/bin/
 ADD utilities.sh /usr/bin/
-ADD test /tmp/test
 
-RUN /usr/bin/run-database.sh --initialize && \
-    bats /tmp/test && \
-    rm -rf "$DATA_DIRECTORY"/*
+ADD test /tmp/test
+RUN bats /tmp/test
 
 VOLUME ["$DATA_DIRECTORY"]
 EXPOSE 3306

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -8,6 +8,7 @@ ADD templates/etc/apt/sources.list.d /etc/apt/sources.list.d
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 5072E1F5 && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        faketime \
         netcat \
         perl \
         procps \
@@ -21,14 +22,15 @@ ADD templates/etc/mysql /etc/mysql
 ENV DATA_DIRECTORY /var/db
 RUN mkdir -p "$DATA_DIRECTORY" && chown -R mysql:mysql "$DATA_DIRECTORY"
 
+ADD run-database.sh /usr/bin/
+ADD utilities.sh /usr/bin/
 ADD test /tmp/test
-RUN mysql_install_db --user=mysql -ldata="$DATA_DIRECTORY" && \
+
+RUN /usr/bin/run-database.sh --initialize && \
     bats /tmp/test && \
     rm -rf "$DATA_DIRECTORY"/*
 
 VOLUME ["$DATA_DIRECTORY"]
 EXPOSE 3306
 
-ADD run-database.sh /usr/bin/
-ADD utilities.sh /usr/bin/
 ENTRYPOINT ["run-database.sh"]

--- a/5.6/run-database.sh
+++ b/5.6/run-database.sh
@@ -2,9 +2,9 @@
 
 . /usr/bin/utilities.sh
 
-if [[ "$1" == "--initialize" ]]; then
-  sed "s:DATA_DIRECTORY:${DATA_DIRECTORY}:g" /etc/mysql/conf.d/overrides.cnf.template > /etc/mysql/conf.d/overrides.cnf
+sed "s:DATA_DIRECTORY:${DATA_DIRECTORY}:g" /etc/mysql/conf.d/overrides.cnf.template > /etc/mysql/conf.d/overrides.cnf
 
+if [[ "$1" == "--initialize" ]]; then
   mkdir -p "$DATA_DIRECTORY/ssl"
   cd "$DATA_DIRECTORY/ssl"
   # All of these certificates need to be generated and signed in the past.

--- a/5.6/run-database.sh
+++ b/5.6/run-database.sh
@@ -3,6 +3,21 @@
 . /usr/bin/utilities.sh
 
 if [[ "$1" == "--initialize" ]]; then
+  mkdir -p "$DATA_DIRECTORY/ssl"
+  cd "$DATA_DIRECTORY/ssl"
+  # All of these certificates need to be generated and signed in the past.
+  # Otherwise, MySQL can reject the configuration with an error indicating that
+  # it thinks their start dates are in the future.
+  faketime 'yesterday' openssl genrsa 2048 > ca-key.pem
+  faketime 'yesterday' openssl req -sha1 -new -x509 -nodes -days 10000 -key ca-key.pem -batch > ca-cert.pem
+  faketime 'yesterday' openssl req -sha1 -newkey rsa:2048 -days 10000 -nodes -keyout server-key-pkcs-8.pem -batch  > server-req.pem
+  faketime 'yesterday' openssl x509 -sha1 -req -in server-req.pem -days 10000  -CA ca-cert.pem -CAkey ca-key.pem -set_serial 01 > server-cert.pem
+  # MySQL requires the key to be PKCS #1-formatted; modern versions of OpenSSL
+  # will generate a key in PKCS #8 format. This call ensures that the key is in
+  # PKCS #1 format. Reference: https://bugs.mysql.com/bug.php?id=71271
+  openssl rsa -in server-key-pkcs-8.pem -out server-key.pem
+  cd -
+
   chown -R mysql:mysql "$DATA_DIRECTORY"
 
   mysql_install_db --user=mysql -ldata="$DATA_DIRECTORY"
@@ -11,30 +26,31 @@ if [[ "$1" == "--initialize" ]]; then
   until nc -z localhost 3306; do sleep 0.1; done
 
   mysql -e "GRANT ALL ON *.* to 'root'@'%' IDENTIFIED BY '$PASSPHRASE'"
-  mysql -e "GRANT ALL ON ${DATABASE:-db}.* to '${USERNAME:-aptible}'@'%' IDENTIFIED BY '$PASSPHRASE'"
+  mysql -e "GRANT ALL ON ${DATABASE:-db}.* to '${USERNAME:-aptible}-nossl'@'%' IDENTIFIED BY '$PASSPHRASE'"
+  mysql -e "GRANT ALL ON ${DATABASE:-db}.* to '${USERNAME:-aptible}'@'%' IDENTIFIED BY '$PASSPHRASE' REQUIRE SSL"
   mysql -e "CREATE DATABASE ${DATABASE:-db}"
   service mysql stop
 
 elif [[ "$1" == "--client" ]]; then
   [ -z "$2" ] && echo "docker run -it aptible/mysql --client mysql://..." && exit
   parse_url "$2"
-  MYSQL_PWD="$password" mysql --host="$host" --port="$port" --user="$user" "$database"
+  MYSQL_PWD="$password" mysql --host="$host" --port="$port" --user="$user" "$database" --ssl
 
 elif [[ "$1" == "--dump" ]]; then
   [ -z "$2" ] && echo "docker run aptible/mysql --dump mysql://... > dump.sql" && exit
   parse_url "$2"
-  MYSQL_PWD="$password" mysqldump --host="$host" --port="$port" --user="$user" "$database"
+  MYSQL_PWD="$password" mysqldump --host="$host" --port="$port" --user="$user" "$database" --ssl
 
 elif [[ "$1" == "--restore" ]]; then
   [ -z "$2" ] && echo "docker run -i aptible/mysql --restore mysql://... < dump.sql" && exit
   parse_url "$2"
-  MYSQL_PWD="$password" mysql --host="$host" --port="$port" --user="$user" "$database"
+  MYSQL_PWD="$password" mysql --host="$host" --port="$port" --user="$user" "$database" --ssl
 
 elif [[ "$1" == "--readonly" ]]; then
   echo "Starting MySQL in read-only mode..."
-  mysqld_safe --read-only
+  mysqld_safe --read-only --ssl
 
 else
-  mysqld_safe
+  mysqld_safe --ssl
 
 fi

--- a/5.6/templates/etc/mysql/conf.d/overrides.cnf
+++ b/5.6/templates/etc/mysql/conf.d/overrides.cnf
@@ -17,5 +17,13 @@ expire_logs_days = 10
 max_binlog_size = 100M
 max_connect_errors = 10512000
 
+ssl-ca=/var/db/ssl/ca-cert.pem
+ssl-cert=/var/db/ssl/server-cert.pem
+ssl-key=/var/db/ssl/server-key.pem
+ssl-cipher=DHE-RSA-AES256-SHA:AES128-SHA
+
+[client]
+ssl-cipher=DHE-RSA-AES256-SHA:AES128-SHA
+
 [innodb]
 innodb_flush_method=normal

--- a/5.6/templates/etc/mysql/conf.d/overrides.cnf.template
+++ b/5.6/templates/etc/mysql/conf.d/overrides.cnf.template
@@ -1,6 +1,6 @@
 [mysqld]
 bind-address = 0.0.0.0
-datadir = /var/db
+datadir = DATA_DIRECTORY
 skip-external-locking
 
 key_buffer_size = 16M
@@ -17,9 +17,9 @@ expire_logs_days = 10
 max_binlog_size = 100M
 max_connect_errors = 10512000
 
-ssl-ca=/var/db/ssl/ca-cert.pem
-ssl-cert=/var/db/ssl/server-cert.pem
-ssl-key=/var/db/ssl/server-key.pem
+ssl-ca=DATA_DIRECTORY/ssl/ca-cert.pem
+ssl-cert=DATA_DIRECTORY/ssl/server-cert.pem
+ssl-key=DATA_DIRECTORY/ssl/server-key.pem
 ssl-cipher=DHE-RSA-AES256-SHA:AES128-SHA
 
 [client]

--- a/5.6/test/mysql.bats
+++ b/5.6/test/mysql.bats
@@ -6,6 +6,7 @@ setup() {
 
 teardown() {
   service mysql stop
+  while [ -f /var/run/mysqld/mysqld.pid ]; do sleep 0.1; done
 }
 
 @test "It should install MySQL 5.6.25" {
@@ -14,11 +15,18 @@ teardown() {
 }
 
 @test "It should support SSL connections" {
-  skip
+  have_ssl=$(mysql -Ee "show variables where variable_name = 'have_ssl'" | grep Value | awk '{ print $2 }')
+  [[ "$have_ssl" == "YES" ]]
 }
 
-@test "It should require SSL" {
-  skip
+@test "It should be built with OpenSSL support" {
+  have_openssl=$(mysql -Ee "show variables where variable_name = 'have_openssl'" | grep Value | awk '{ print $2 }')
+  [[ "$have_openssl" == "YES" ]]
+}
+
+@test "It should allow connections over SSL" {
+  cipher=$(mysql -Ee "show status like 'Ssl_cipher'" | grep Value | awk '{ print $2 }')
+  [[ "$cipher" == "DHE-RSA-AES256-SHA" ]]
 }
 
 @test "It should set max_connect_errors to a large value" {


### PR DESCRIPTION
Enabling SSL support, requiring it for the `aptible` user. Forcing/using SSL with MySQL is a little wonky; in 5.6 it's essentially a request from both the client and server side so long as the server decides it can support it. Because of this, I'm also adding a `-nossl` user that doesn't require SSL as a workaround for cases where clients might not fully support SSL, since otherwise an old/broken client might be unable to connect.

This patch needs some more internal testing in a sandbox setting, especially for upgrades, so please don't merge immediately.