### PR TITLE
Upgrade to 5.6.26

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/aptible/debian:wheezy
 # cf. docker-library/mysql: explicitly create the user so uid and gid are consistent.
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-ENV MYSQL_VERSION 5.6.25-1debian7
+ENV MYSQL_VERSION 5.6.26-1debian7
 ADD templates/etc/apt/sources.list.d /etc/apt/sources.list.d
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 5072E1F5 && \
     apt-get update && \

--- a/5.6/test/mysql.bats
+++ b/5.6/test/mysql.bats
@@ -18,9 +18,9 @@ teardown() {
   unset OLD_DATA_DIRECTORY
 }
 
-@test "It should install MySQL 5.6.25" {
+@test "It should install MySQL 5.6.26" {
   run mysqld --version
-  [[ "$output" =~ "Ver 5.6.25"  ]]
+  [[ "$output" =~ "Ver 5.6.26"  ]]
 }
 
 @test "It should support SSL connections" {


### PR DESCRIPTION
5.6.25 is no longer available from repo.mysql.com:

```
# apt-cache madison mysql-server
mysql-server | 5.6.26-1debian7 | http://repo.mysql.com/apt/debian/ wheezy/mysql-5.6 amd64 Packages
mysql-server | 5.5.44-0+deb7u1 | http://security.debian.org/ wheezy/updates/main amd64 Packages
mysql-server | 5.5.40-0+wheezy1 | http://http.debian.net/debian/ wheezy/main amd64 Packages
# apt-cache madison mysql-client
mysql-client | 5.6.26-1debian7 | http://repo.mysql.com/apt/debian/ wheezy/mysql-5.6 amd64 Packages
mysql-client | 5.5.44-0+deb7u1 | http://security.debian.org/ wheezy/updates/main amd64 Packages
mysql-client | 5.5.40-0+wheezy1 | http://http.debian.net/debian/ wheezy/main amd64 Packages
```

Switching to 5.6.26, release notes here: http://dev.mysql.com/doc/relnotes/mysql/5.6/en/news-5-6-26.html