### PR TITLE
Use more robust replication configuration

### DIFF
--- a/templates/etc/mysql/conf.d/replication.cnf.template
+++ b/templates/etc/mysql/conf.d/replication.cnf.template
@@ -5,3 +5,6 @@ server-id = __SERVER_ID__
 binlog-format = ROW
 expire-logs-days = 10
 max-binlog-size = 100M
+
+# Log name options are injected here by bin/run-database.sh at runtime
+# depending on this server's role.


### PR DESCRIPTION
While working on MySQL 5.7 I stumbled upon a couple improvements we can make for replication to be safer.

None of this needs to be backported to running instances that might have been started with the new image today; it's just something that needs to not change once we start creating replicas (which we haven't yet).

---

Commit message follows:

Update the server-id file, give a fixed name to the relay log.

Server ID:

MySQL 5.7 doesn't like having files in its data dir unless they start
with ".". We can exclude files manually, but it's better to just do what
MySQL expects here.

We haven't deployed any replicas yet, so there's no need to update
instances. Servers that were deployed with `server-id` will reset to 1
(which is fine because they are masters).

Relay Log:

The relay log's name is determined by MySQL somehow dynamically. In
MySQL 5.6, this is fine, because the name ends up fixed. In 5.7, that's
not fine, because the name is based on the hostname of the instance.

By using a fixed name, we don't depend on the slave's hostname for
replication to work.