### PR TITLE
Mysql 5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - DOCKER_CONFIG=./.docker
   matrix:
     - TAG=5.6
+    - TAG=5.7
 
 script:
   - make build

--- a/5.6/config.mk
+++ b/5.6/config.mk
@@ -1,1 +1,2 @@
-export MYSQL_VERSION = 5.6.29-1debian7
+export MYSQL_VERSION = 5.6
+export MYSQL_PACKAGE_VERSION = 5.6.29-1debian7

--- a/5.6/templates/etc/mysql/conf.d/overrides-5.6.cnf
+++ b/5.6/templates/etc/mysql/conf.d/overrides-5.6.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+myisam-recover = BACKUP

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -3,10 +3,10 @@ FROM quay.io/aptible/debian:wheezy
 # cf. docker-library/mysql: explicitly create the user so uid and gid are consistent.
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-ENV MYSQL_VERSION <%= ENV.fetch 'MYSQL_VERSION' %>
-ENV MYSQL_PACKAGE_VERSION <%= ENV.fetch 'MYSQL_PACKAGE_VERSION' %>
+ENV MYSQL_VERSION 5.7
+ENV MYSQL_PACKAGE_VERSION 5.7.11-1debian7
 
-ADD <%= ENV.fetch 'TAG' %>/templates/etc/apt/sources.list.d /etc/apt/sources.list.d
+ADD 5.7/templates/etc/apt/sources.list.d /etc/apt/sources.list.d
 
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 5072E1F5 && \
     apt-get update && \
@@ -24,7 +24,7 @@ RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 5072E1F5 && \
 ENV CONF_DIRECTORY /etc/mysql
 RUN rm -r "$CONF_DIRECTORY"
 ADD templates/etc/mysql $CONF_DIRECTORY
-ADD <%= ENV.fetch 'TAG' %>/templates/etc/mysql $CONF_DIRECTORY
+ADD 5.7/templates/etc/mysql $CONF_DIRECTORY
 
 ENV DATA_DIRECTORY /var/db
 RUN mkdir -p "$DATA_DIRECTORY" && chown -R mysql:mysql "$DATA_DIRECTORY"

--- a/5.7/config.mk
+++ b/5.7/config.mk
@@ -1,0 +1,2 @@
+export MYSQL_VERSION = 5.7
+export MYSQL_PACKAGE_VERSION = 5.7.11-1debian7

--- a/5.7/templates/etc/apt/sources.list.d/mysql.list
+++ b/5.7/templates/etc/apt/sources.list.d/mysql.list
@@ -1,0 +1,1 @@
+deb http://repo.mysql.com/apt/debian/ wheezy mysql-5.7

--- a/5.7/templates/etc/mysql/conf.d/overrides-5.7.cnf
+++ b/5.7/templates/etc/mysql/conf.d/overrides-5.7.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+myisam-recover-options = BACKUP

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -95,6 +95,8 @@ function mysql_start_background () {
 }
 
 function mysql_start_foreground () {
+  unset SSL_CERTIFICATE
+  unset SSL_KEY
   exec mysqld_safe --defaults-file="${CONF_DIRECTORY}/my.cnf" --ssl "$@"
 }
 
@@ -109,8 +111,9 @@ if [[ "$1" == "--initialize" ]]; then
   mkdir -p "$(dirname "${DATA_DIRECTORY}/${SERVER_ID_FILE}")"
   echo 1 > "${DATA_DIRECTORY}/${SERVER_ID_FILE}"
 
-  mysql_initialize_data_dir
+  mysql_initialize_certs
   mysql_initialize_conf_dir
+  mysql_initialize_data_dir
   mysql_start_background
 
   # Create our DB
@@ -166,8 +169,9 @@ elif [[ "$1" == "--initialize-from" ]]; then
   # Create slave configuration
   echo "$MYSQL_REPLICATION_SLAVE_SERVER_ID" > "${DATA_DIRECTORY}/${SERVER_ID_FILE}"
 
-  mysql_initialize_data_dir
+  mysql_initialize_certs
   mysql_initialize_conf_dir
+  mysql_initialize_data_dir
 
   # Now, retrieve data from the master
   # Note that this will fail if binary logging is not enabled on the master (because we use --master-data, which

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -19,7 +19,8 @@ elif [[ "$MYSQL_VERSION" = "5.7" ]]; then
   SSL_CLIENT_OPT="--ssl-mode=REQUIRED"
   MYSQL_INSTALL_DB_BASE_COMMAND="mysqld --initialize-insecure"
 else
-  exit "Unrecognized MYSQL_VERSION: $MYSQL_VERSION"
+  echo "Unrecognized MYSQL_VERSION: $MYSQL_VERSION"
+  exit 1
 fi
 
 

--- a/latest.mk
+++ b/latest.mk
@@ -1,1 +1,1 @@
-LATEST_TAG = 5.6
+LATEST_TAG = 5.7

--- a/templates/etc/mysql/conf.d/overrides.cnf.template
+++ b/templates/etc/mysql/conf.d/overrides.cnf.template
@@ -3,6 +3,8 @@ bind-address = 0.0.0.0
 port = __PORT__
 
 datadir = __DATA_DIRECTORY__
+secure-file-priv = __DATA_DIRECTORY__
+
 skip-external-locking
 
 key_buffer_size = 16M

--- a/templates/etc/mysql/conf.d/overrides.cnf.template
+++ b/templates/etc/mysql/conf.d/overrides.cnf.template
@@ -10,16 +10,14 @@ max_allowed_packet = 16M
 thread_stack = 192K
 thread_cache_size = 8
 
-myisam-recover = BACKUP
-
 query_cache_limit = 1M
 query_cache_size = 16M
 
 max_connect_errors = 10512000
 
-ssl-ca   = __DATA_DIRECTORY__/ssl/ca-cert.pem
-ssl-cert = __DATA_DIRECTORY__/ssl/server-cert.pem
-ssl-key  = __DATA_DIRECTORY__/ssl/server-key.pem
+ssl-ca   = __CONF_DIRECTORY__/ssl/ca-cert.pem
+ssl-cert = __CONF_DIRECTORY__/ssl/server-cert.pem
+ssl-key  = __CONF_DIRECTORY__/ssl/server-key.pem
 
 ssl-cipher = __SSL_CIPHERS__
 

--- a/templates/etc/mysql/conf.d/replication.cnf.template
+++ b/templates/etc/mysql/conf.d/replication.cnf.template
@@ -5,3 +5,6 @@ server-id = __SERVER_ID__
 binlog-format = ROW
 expire-logs-days = 10
 max-binlog-size = 100M
+
+# Log name options are injected here by bin/run-database.sh at runtime
+# depending on this server's role.

--- a/templates/etc/mysql/my.cnf.template
+++ b/templates/etc/mysql/my.cnf.template
@@ -54,4 +54,4 @@ symbolic-links=0
 # * IMPORTANT: Additional settings that can override those from this file!
 #   The files must end with '.cnf', otherwise they'll be ignored.
 #
-!includedir /etc/mysql/conf.d/
+!includedir __CONF_DIRECTORY__/conf.d

--- a/test/mysql.bats
+++ b/test/mysql.bats
@@ -110,3 +110,10 @@ teardown() {
   [ "${lines[1]}" = "i: 1" ]
   [ "${#lines[@]}" = "2" ]
 }
+
+@test "It should not let users read private key material" {
+  mysql db -e "CREATE TABLE data (col TEXT);"
+  run mysql db -e "LOAD DATA INFILE '/etc/mysql/ssl/server-key.pem' INTO TABLE data;"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "cannot execute this statement" ]]
+}

--- a/test/mysql.bats
+++ b/test/mysql.bats
@@ -2,8 +2,11 @@
 
 setup() {
   export OLD_DATA_DIRECTORY="$DATA_DIRECTORY"
+  export OLD_CONF_DIRECTORY="$CONF_DIRECTORY"
   export DATA_DIRECTORY=/tmp/datadir
+  export CONF_DIRECTORY=/tmp/confdir
   mkdir "$DATA_DIRECTORY"
+  cp -r "$OLD_CONF_DIRECTORY" "$CONF_DIRECTORY"  # Templates are in there
   PASSPHRASE=foobar /usr/bin/run-database.sh --initialize
   while [ -f /var/run/mysqld/mysqld.pid ]; do sleep 0.1; done
   /usr/bin/run-database.sh > /tmp/mysql.log 2>&1 &
@@ -14,13 +17,16 @@ teardown() {
   mysqladmin shutdown
   while [ -f /var/run/mysqld/mysqld.pid ]; do sleep 0.1; done
   rm -rf "$DATA_DIRECTORY"
+  rm -rf "$CONF_DIRECTORY"
   export DATA_DIRECTORY="$OLD_DATA_DIRECTORY"
+  export CONF_DIRECTORY="$OLD_CONF_DIRECTORY"
   unset OLD_DATA_DIRECTORY
+  unset OLD_CONF_DIRECTORY
 }
 
-@test "It should install MySQL $MYSQL_VERSION" {
+@test "It should install MySQL $MYSQL_PACKAGE_VERSION" {
   run mysqld --version
-  [[ "$output" =~ "Ver ${MYSQL_VERSION%%-*}" ]]  # Package version up to -
+  [[ "$output" =~ "Ver ${MYSQL_PACKAGE_VERSION%%-*}" ]]  # Package version up to -
 }
 
 @test "It should bring up a working MySQL instance with aptible and aptible-nossl users" {
@@ -37,17 +43,17 @@ teardown() {
 }
 
 @test "It should support SSL connections" {
-  have_ssl=$(mysql -Ee "show variables where variable_name = 'have_ssl'" | grep Value | awk '{ print $2 }')
+  have_ssl=$(run-database.sh --client "mysql://root@localhost/db" -Ee "show variables where variable_name = 'have_ssl'" | grep Value | awk '{ print $2 }')
   [[ "$have_ssl" == "YES" ]]
 }
 
 @test "It should be built with OpenSSL support" {
-  have_openssl=$(mysql -Ee "show variables where variable_name = 'have_openssl'" | grep Value | awk '{ print $2 }')
+  have_openssl=$(run-database.sh --client "mysql://root@localhost/db" -Ee "show variables where variable_name = 'have_openssl'" | grep Value | awk '{ print $2 }')
   [[ "$have_openssl" == "YES" ]]
 }
 
 @test "It should allow connections over SSL" {
-  cipher=$(mysql -Ee "show status like 'Ssl_cipher'" | grep Value | awk '{ print $2 }')
+  cipher=$(run-database.sh --client "mysql://root@localhost/db" -Ee "show status like 'Ssl_cipher'" | grep Value | awk '{ print $2 }')
   [[ "$cipher" == "DHE-RSA-AES256-SHA" ]]
 }
 


### PR DESCRIPTION
This adds support for MySQL 5.7 (it incorporates the commit from #18, but that should be merged separately; I'll rebase once it's merged). 

There's nothing particularly exciting here, but the main change is that certs would no longer be stored in the `DATA_DIRECTORY` (which will resolve #16). This is probably a good thing, but if @aaw or @fancyremarker could confirm, that'd be great :).

---

Commit message follows:

This includes a few changes on the image:

- SSL Certs are no longer stored in the data directory. Instead, they're
  stored in the conf directory, which is more consistent with what we do
  for other databases.
- CONF_DIRECTORY is made configurable, so that the BATS test can run in
  a fully independent environment, which ensures we don't accidentally
  e.g. leave certs on the image or reuse them across tests.