### PR TITLE
Captain comeback support

### DIFF
--- a/5.6/config.mk
+++ b/5.6/config.mk
@@ -1,2 +1,2 @@
 export MYSQL_VERSION = 5.6
-export MYSQL_PACKAGE_VERSION = 5.6.30-1debian7
+export MYSQL_PACKAGE_VERSION = 5.6.32-1debian7

--- a/5.7/config.mk
+++ b/5.7/config.mk
@@ -1,2 +1,2 @@
 export MYSQL_VERSION = 5.7
-export MYSQL_PACKAGE_VERSION = 5.7.12-1debian7
+export MYSQL_PACKAGE_VERSION = 5.7.14-1debian7

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ This status variable is non-empty exactly when SSL is enabled for the session.
 
 ## Available Tags
 
-* `latest`: Currently MySQL 5.7.11 (Community Server)
-* `5.7`: MySQL 5.7.11 (Community Server)
-* `5.6`: MySQL 5.6.29 (Community Server)
+* `latest`: Currently MySQL 5.7.14 (Community Server)
+* `5.7`: MySQL 5.7.14 (Community Server)
+* `5.6`: MySQL 5.6.32 (Community Server)
 
 ## Tests
 

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -81,7 +81,7 @@ function mysql_initialize_data_dir () {
 
 
 function mysql_start_background () {
-  mysqld_safe --defaults-file="${CONF_DIRECTORY}/my.cnf" --ssl &
+  /usr/sbin/mysqld --defaults-file="${CONF_DIRECTORY}/my.cnf" --ssl &
   until nc -z localhost 3306; do sleep 0.1; done
   until mysqladmin ping; do sleep 0.1; done
 }
@@ -89,7 +89,7 @@ function mysql_start_background () {
 function mysql_start_foreground () {
   unset SSL_CERTIFICATE
   unset SSL_KEY
-  exec mysqld_safe --defaults-file="${CONF_DIRECTORY}/my.cnf" --ssl "$@"
+  exec /usr/sbin/mysqld --defaults-file="${CONF_DIRECTORY}/my.cnf" --ssl "$@"
 }
 
 

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -83,6 +83,7 @@ function mysql_initialize_data_dir () {
 function mysql_start_background () {
   mysqld_safe --defaults-file="${CONF_DIRECTORY}/my.cnf" --ssl &
   until nc -z localhost 3306; do sleep 0.1; done
+  until mysqladmin ping; do sleep 0.1; done
 }
 
 function mysql_start_foreground () {

--- a/templates/etc/mysql/my.cnf.template
+++ b/templates/etc/mysql/my.cnf.template
@@ -1,51 +1,23 @@
-# Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; version 2 of the License.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
-
-#
-# The MySQL Community Server configuration file.
-#
-# For explanations see
-# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+# We use this config file for default paths that the MySQL server would
+# otherwise be expected to use. Most of this gets overriden in our other
+# configuration files.
 
 [client]
-port		= 3306
-socket		= /var/run/mysqld/mysqld.sock
-
-[mysqld_safe]
-pid-file	= /var/run/mysqld/mysqld.pid
-socket		= /var/run/mysqld/mysqld.sock
-nice		= 0
+port    = 3306
+socket  = /var/run/mysqld/mysqld.sock
 
 [mysqld]
-user		= mysql
-pid-file	= /var/run/mysqld/mysqld.pid
-socket		= /var/run/mysqld/mysqld.sock
-port		= 3306
-basedir		= /usr
-datadir		= /var/lib/mysql
-tmpdir		= /tmp
-lc-messages-dir	= /usr/share/mysql
-explicit_defaults_for_timestamp
-
-# Instead of skip-networking the default is now to listen only on
-# localhost which is more compatible and is not less secure.
-bind-address	= 127.0.0.1
-
-log-error	= /var/log/mysql/error.log
+user            = mysql
+pid-file        = /var/run/mysqld/mysqld.pid
+socket          = /var/run/mysqld/mysqld.sock
+port            = 3306
+basedir         = /usr
+plugin-dir      = /usr/lib/mysql/plugin
+tmpdir          = /tmp
+lc-messages-dir = /usr/share/mysql
 
 # Recommended in standard MySQL setup
+explicit_defaults_for_timestamp
 sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES
 
 # Disabling symbolic-links is recommended to prevent assorted security risks

--- a/test-replication.sh
+++ b/test-replication.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+IMG="$1"
+
+MASTER_CONTAINER="mysql-master"
+MASTER_DATA_CONTAINER="${MASTER_CONTAINER}-data"
+SLAVE_CONTAINER="mysql-slave"
+SLAVE_DATA_CONTAINER="${SLAVE_CONTAINER}-data"
+
+function cleanup {
+  echo "Cleaning up"
+  docker rm -f "$MASTER_CONTAINER" "$MASTER_DATA_CONTAINER" "$SLAVE_CONTAINER" "$SLAVE_DATA_CONTAINER" || true
+}
+
+trap cleanup EXIT
+cleanup
+
+USER=testuser
+PASSPHRASE=testpass
+DATABASE=testdb
+
+
+echo "Initializing data containers"
+
+docker create --name "$MASTER_DATA_CONTAINER" "$IMG"
+docker create --name "$SLAVE_DATA_CONTAINER" "$IMG"
+
+
+echo "Initializing replication master"
+
+MASTER_PORT=33061  # Test with a nonstandard port
+
+docker run -it --rm \
+  -e USERNAME="$USER" -e PASSPHRASE="$PASSPHRASE" -e DATABASE="$DATABASE" \
+  --volumes-from "$MASTER_DATA_CONTAINER" \
+  "$IMG" --initialize
+
+docker run -d --name="$MASTER_CONTAINER" \
+  -e "PORT=${MASTER_PORT}" \
+  --volumes-from "$MASTER_DATA_CONTAINER" \
+  "$IMG"
+
+
+until docker exec -it "$MASTER_CONTAINER" mysqladmin ping; do sleep 0.1; done
+
+MASTER_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$MASTER_CONTAINER")"
+MASTER_USER_URL="mysql://$USER:$PASSPHRASE@$MASTER_IP:$MASTER_PORT/$DATABASE"
+MASTER_ROOT_URL="mysql://root:$PASSPHRASE@$MASTER_IP:$MASTER_PORT/$DATABASE"
+
+
+echo "Creating test_before table"
+
+docker run -it --rm "$IMG" --client "$MASTER_USER_URL" -e "CREATE TABLE test_before (col TEXT);"
+docker run -it --rm "$IMG" --client "$MASTER_USER_URL" -e "INSERT INTO test_before VALUES ('TEST DATA BEFORE');"
+
+
+echo "Initializing replication slave"
+SLAVE_PORT=33062
+
+docker run -it --rm \
+  --volumes-from "$SLAVE_DATA_CONTAINER" \
+  "$IMG" --initialize-from "$MASTER_USER_URL"   # Use the user URL, but --initialize-from will use root instead
+
+docker run -d --name "$SLAVE_CONTAINER" \
+  -e "PORT=${SLAVE_PORT}" \
+  --volumes-from "$SLAVE_DATA_CONTAINER" \
+  "$IMG"
+
+
+SLAVE_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$SLAVE_CONTAINER")"
+SLAVE_ROOT_URL="mysql://root:$PASSPHRASE@$SLAVE_IP:$SLAVE_PORT/$DATABASE"
+SLAVE_USER_URL="mysql://$USER:$PASSPHRASE@$SLAVE_IP:$SLAVE_PORT/$DATABASE"
+
+
+until docker exec -it "$SLAVE_CONTAINER" mysqladmin ping; do sleep 0.1; done
+docker run -it --rm "$IMG" --client "$SLAVE_ROOT_URL" -e "SHOW SLAVE STATUS \G"
+
+
+# Create a test table now that replication has started
+docker run -it --rm "$IMG" --client "$MASTER_USER_URL" -e "CREATE TABLE test_after (col TEXT);"
+docker run -it --rm "$IMG" --client "$MASTER_USER_URL" -e "INSERT INTO test_after VALUES ('TEST DATA AFTER');"
+
+# Give replication time it needs to catch up (should usually be essentially instantaneous, but who knows,
+# some CI systems might run slower.
+until docker run --rm "$IMG" --client "$SLAVE_ROOT_URL" -e "SHOW SLAVE STATUS \G" | grep "Waiting for master to send event"; do sleep 0.1; done
+
+# Check that data is present in both tables
+docker run -it --rm "$IMG" --client "$SLAVE_USER_URL" -e 'SELECT * FROM test_before;' | grep 'TEST DATA BEFORE'
+docker run -it --rm "$IMG" --client "$SLAVE_USER_URL" -e 'SELECT * FROM test_after;' | grep 'TEST DATA AFTER'

--- a/test-restart.sh
+++ b/test-restart.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+IMG="$1"
+
+MYSQL_CONTAINER="mysql"
+DATA_CONTAINER="${MYSQL_CONTAINER}-data"
+
+function cleanup {
+  echo "Cleaning up"
+  docker rm -f "$MYSQL_CONTAINER" "$DATA_CONTAINER" >/dev/null 2>&1 || true
+}
+
+function wait_for_mysql {
+  for _ in $(seq 1 1000); do
+    if docker exec -it "$MYSQL_CONTAINER" mysqladmin ping >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  echo "MySQL never came online"
+  docker logs "$MYSQL_CONTAINER"
+  return 1
+}
+
+trap cleanup EXIT
+cleanup
+
+echo "Creating data container"
+docker create --name "$DATA_CONTAINER" "$IMG"
+
+echo "Starting DB"
+docker run -it --rm \
+  -e USERNAME=user -e PASSPHRASE=pass -e DATABASE=db \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG" --initialize \
+  >/dev/null 2>&1
+
+docker run -d --name="$MYSQL_CONTAINER" \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG"
+
+echo "Waiting for DB to come online"
+wait_for_mysql
+
+echo "Verifying MySQL shutdown message isn't present"
+docker logs "$MYSQL_CONTAINER" 2>&1 | grep -qv "Shutdown complete"
+
+echo "Restarting DB container"
+date
+docker top "$MYSQL_CONTAINER"
+docker restart -t 10 "$MYSQL_CONTAINER"
+
+echo "Waiting for DB to come back online"
+wait_for_mysql
+
+echo "DB came back online; checking for clean shutdown"
+date
+docker logs "$MYSQL_CONTAINER" 2>&1 | grep "Shutdown complete"
+docker logs "$MYSQL_CONTAINER" 2>&1 | grep -qv "Crash recovery finished"
+
+echo "Attempting unclean shutdown"
+docker kill -s KILL "$MYSQL_CONTAINER"
+docker start "$MYSQL_CONTAINER"
+
+
+echo "Waiting for DB to come back online"
+wait_for_mysql
+
+docker logs "$MYSQL_CONTAINER" 2>&1 | grep "Crash recovery finished"

--- a/test.sh
+++ b/test.sh
@@ -2,93 +2,11 @@
 set -o errexit
 set -o nounset
 
-
 IMG="$REGISTRY/$REPOSITORY:$TAG"
 
-MASTER_CONTAINER="mysql-master"
-MASTER_DATA_CONTAINER="${MASTER_CONTAINER}-data"
-SLAVE_CONTAINER="mysql-slave"
-SLAVE_DATA_CONTAINER="${SLAVE_CONTAINER}-data"
+./test-restart.sh "$IMG"
+./test-replication.sh "$IMG"
 
-function cleanup {
-  echo "Cleaning up"
-  docker rm -f "$MASTER_CONTAINER" "$MASTER_DATA_CONTAINER" "$SLAVE_CONTAINER" "$SLAVE_DATA_CONTAINER" || true
-}
-
-trap cleanup EXIT
-cleanup
-
-USER=testuser
-PASSPHRASE=testpass
-DATABASE=testdb
-
-
-echo "Initializing data containers"
-
-docker create --name "$MASTER_DATA_CONTAINER" "$IMG"
-docker create --name "$SLAVE_DATA_CONTAINER" "$IMG"
-
-
-echo "Initializing replication master"
-
-MASTER_PORT=33061  # Test with a nonstandard port
-
-docker run -it --rm \
-  -e USERNAME="$USER" -e PASSPHRASE="$PASSPHRASE" -e DATABASE="$DATABASE" \
-  --volumes-from "$MASTER_DATA_CONTAINER" \
-  "$IMG" --initialize
-
-docker run -d --name="$MASTER_CONTAINER" \
-  -e "PORT=${MASTER_PORT}" \
-  --volumes-from "$MASTER_DATA_CONTAINER" \
-  "$IMG"
-
-
-until docker exec -it "$MASTER_CONTAINER" mysqladmin ping; do sleep 0.1; done
-
-MASTER_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$MASTER_CONTAINER")"
-MASTER_USER_URL="mysql://$USER:$PASSPHRASE@$MASTER_IP:$MASTER_PORT/$DATABASE"
-MASTER_ROOT_URL="mysql://root:$PASSPHRASE@$MASTER_IP:$MASTER_PORT/$DATABASE"
-
-
-echo "Creating test_before table"
-
-docker run -it --rm "$IMG" --client "$MASTER_USER_URL" -e "CREATE TABLE test_before (col TEXT);"
-docker run -it --rm "$IMG" --client "$MASTER_USER_URL" -e "INSERT INTO test_before VALUES ('TEST DATA BEFORE');"
-
-
-echo "Initializing replication slave"
-SLAVE_PORT=33062
-
-docker run -it --rm \
-  --volumes-from "$SLAVE_DATA_CONTAINER" \
-  "$IMG" --initialize-from "$MASTER_USER_URL"   # Use the user URL, but --initialize-from will use root instead
-
-docker run -d --name "$SLAVE_CONTAINER" \
-  -e "PORT=${SLAVE_PORT}" \
-  --volumes-from "$SLAVE_DATA_CONTAINER" \
-  "$IMG"
-
-
-SLAVE_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$SLAVE_CONTAINER")"
-SLAVE_ROOT_URL="mysql://root:$PASSPHRASE@$SLAVE_IP:$SLAVE_PORT/$DATABASE"
-SLAVE_USER_URL="mysql://$USER:$PASSPHRASE@$SLAVE_IP:$SLAVE_PORT/$DATABASE"
-
-
-until docker exec -it "$SLAVE_CONTAINER" mysqladmin ping; do sleep 0.1; done
-docker run -it --rm "$IMG" --client "$SLAVE_ROOT_URL" -e "SHOW SLAVE STATUS \G"
-
-
-# Create a test table now that replication has started
-docker run -it --rm "$IMG" --client "$MASTER_USER_URL" -e "CREATE TABLE test_after (col TEXT);"
-docker run -it --rm "$IMG" --client "$MASTER_USER_URL" -e "INSERT INTO test_after VALUES ('TEST DATA AFTER');"
-
-# Give replication time it needs to catch up (should usually be essentially instantaneous, but who knows,
-# some CI systems might run slower.
-until docker run --rm "$IMG" --client "$SLAVE_ROOT_URL" -e "SHOW SLAVE STATUS \G" | grep "Waiting for master to send event"; do sleep 0.1; done
-
-# Check that data is present in both tables
-docker run -it --rm "$IMG" --client "$SLAVE_USER_URL" -e 'SELECT * FROM test_before;' | grep 'TEST DATA BEFORE'
-docker run -it --rm "$IMG" --client "$SLAVE_USER_URL" -e 'SELECT * FROM test_after;' | grep 'TEST DATA AFTER'
-
-echo "Test OK!"
+echo "#############"
+echo "# Tests OK! #"
+echo "#############"


### PR DESCRIPTION
Our MySQL docker image does not properly withstand a `docker restart`. First, it fails to shutdown cleanly, and then it doesn't even come back due to a mysterious error in `mysqld_safe` using grep with a broken pipe.

Now, there actually doesn't really appear to be any reason for us to use `mysqld_safe` (see below), so this removes it. It also adds tests that ensure we can recover from a clean or an unclean shutdown.

This also updates MySQL to the latest point release, and adds a possible solution to the (very) occasional error we get about MySQL not being up in our bootstrap script.

cc @fancyremarker @blakepettersson 

Commit message follows:

---

There is hardly anything in mysqld_safe that we use, but there is plenty
we *don't* use.

- First, mysqld_safe is a shell script that runs as PID 1 and
  deliberately ignores all the signals it receives. This is bad for us,
  because we want to be able to issue a `docker restart` to a MySQL
  container. If we keep using mysqld_safe, Docker's SIGTERM will be
  ignored, and we'll receive a SIGKILL.
- Second, mysqld_safe captures error logging output and routes it to a
  file. Once again, we don't want that. We'd rather have it sent to
  stdout.
- Finally, mysqld_safe essentially parses the options from our options
  file to pass them to MySQL as arguments. It's unclear why that's
  useful (we have test doverage for the options we set). It also does a
  ton of other things we don't need, like being compatible with RHEL 5,
  sh, etc., which we don't actually use.

There are two reasons left why mysqld_safe might be useful to us:o

- It restarts MySQL when it dies
- It cleans out old PID files

The latter doesn't seem to be needed (we now have tests for this), and
I'll investigate running databases to check whether the former is
useful.

All in all, mysqld_safe is arguably a tool for another era, and using it
in our Docker image makes little sense (incidentally, Docker does not
use it in their own image).
