### PR TITLE
General query log and slow query log to stdout

### DIFF
--- a/5.6/config.mk
+++ b/5.6/config.mk
@@ -1,2 +1,2 @@
 export MYSQL_VERSION = 5.6
-export MYSQL_PACKAGE_VERSION = 5.6.32-1debian7
+export MYSQL_PACKAGE_VERSION = 5.6.35-1debian7

--- a/5.7/config.mk
+++ b/5.7/config.mk
@@ -1,2 +1,2 @@
 export MYSQL_VERSION = 5.7
-export MYSQL_PACKAGE_VERSION = 5.7.14-1debian7
+export MYSQL_PACKAGE_VERSION = 5.7.17-1debian7

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -35,6 +35,11 @@ ADD bin/utilities.sh /usr/bin/
 ADD test /tmp/test
 RUN bats /tmp/test
 
+ENV DOCKERIZE_VERSION v0.3.0
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
 VOLUME ["$DATA_DIRECTORY"]
 EXPOSE 3306
 

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -32,13 +32,13 @@ RUN mkdir -p "$DATA_DIRECTORY" && chown -R mysql:mysql "$DATA_DIRECTORY"
 ADD bin/run-database.sh /usr/bin/
 ADD bin/utilities.sh /usr/bin/
 
-ADD test /tmp/test
-RUN bats /tmp/test
-
 ENV DOCKERIZE_VERSION v0.3.0
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+ADD test /tmp/test
+RUN bats /tmp/test
 
 VOLUME ["$DATA_DIRECTORY"]
 EXPOSE 3306

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -89,7 +89,7 @@ function mysql_start_background () {
 function mysql_start_foreground () {
   unset SSL_CERTIFICATE
   unset SSL_KEY
-  exec /usr/sbin/mysqld --defaults-file="${CONF_DIRECTORY}/my.cnf" --ssl "$@"
+  exec dockerize -stdout /var/db/general-query-log.log -stdout /var/db/slow-query-log.log usr/sbin/mysqld --defaults-file="${CONF_DIRECTORY}/my.cnf" --ssl "$@"
 }
 
 


### PR DESCRIPTION
This fixes https://github.com/aptible/docker-mysql/issues/1

To use, just log in to server and enable query log and slow query log:

```
set global general_log_file='/var/db/general-query-log.log';
set global general_log= 'ON';
```