### PR TITLE
General and slow query logs

### DIFF
--- a/5.6/config.mk
+++ b/5.6/config.mk
@@ -1,2 +1,2 @@
 export MYSQL_VERSION = 5.6
-export MYSQL_PACKAGE_VERSION = 5.6.32-1debian7
+export MYSQL_PACKAGE_VERSION = 5.6.35-1debian7

--- a/5.7/config.mk
+++ b/5.7/config.mk
@@ -1,2 +1,2 @@
 export MYSQL_VERSION = 5.7
-export MYSQL_PACKAGE_VERSION = 5.7.14-1debian7
+export MYSQL_PACKAGE_VERSION = 5.7.17-1debian7

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -27,7 +27,9 @@ ADD templates/etc/mysql $CONF_DIRECTORY
 ADD <%= ENV.fetch 'TAG' %>/templates/etc/mysql $CONF_DIRECTORY
 
 ENV DATA_DIRECTORY /var/db
-RUN mkdir -p "$DATA_DIRECTORY" && chown -R mysql:mysql "$DATA_DIRECTORY"
+ENV LOG_DIRECTORY /var/log/mysql
+RUN mkdir -p "$DATA_DIRECTORY" "$LOG_DIRECTORY" \
+ && chown -R mysql:mysql "$DATA_DIRECTORY" "$LOG_DIRECTORY"
 
 ADD bin/run-database.sh /usr/bin/
 ADD bin/utilities.sh /usr/bin/

--- a/templates/etc/mysql/conf.d/overrides.cnf.template
+++ b/templates/etc/mysql/conf.d/overrides.cnf.template
@@ -23,6 +23,9 @@ ssl-key  = __CONF_DIRECTORY__/ssl/server-key.pem
 
 ssl-cipher = __SSL_CIPHERS__
 
+general_log_file = __LOG_DIRECTORY__/general.log
+slow_query_log_file = __LOG_DIRECTORY__/slow.log
+
 [client]
 ssl-cipher = __SSL_CIPHERS__
 port = __PORT__


### PR DESCRIPTION
This adds support for forwarding MySQL logs to stdout and fixes #1 (it's also the same as #29).

A few notes:

- We should consider bundling the various `mysql_initialize_XXX`
  functions into a single one. We're starting to have quite a few and
  it'll get unwieldy.
- We don't truncate the logs if they get too big (but our alerting will
  notify us). We can always address this if it turns out to be needed.

---

cc @fancyremarker 