### PR TITLE
Auto-configure from APTIBLE_CONTAINER_SIZE

### DIFF
--- a/5.6/config.mk
+++ b/5.6/config.mk
@@ -1,2 +1,2 @@
 export MYSQL_VERSION = 5.6
-export MYSQL_PACKAGE_VERSION = 5.6.37-1debian7
+export MYSQL_PACKAGE_VERSION = 5.6.38-1debian7

--- a/5.7/config.mk
+++ b/5.7/config.mk
@@ -1,2 +1,2 @@
 export MYSQL_VERSION = 5.7
-export MYSQL_PACKAGE_VERSION = 5.7.19-1debian7
+export MYSQL_PACKAGE_VERSION = 5.7.20-1debian7

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -17,6 +17,7 @@ RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 5072E1F5 && \
         procps \
         "mysql-server=${MYSQL_PACKAGE_VERSION}" \
         "mysql-client=${MYSQL_PACKAGE_VERSION}" \
+        python-minimal \
         && \
     rm -rf /var/lib/apt/lists/*
 
@@ -33,6 +34,7 @@ RUN mkdir -p "$DATA_DIRECTORY" "$LOG_DIRECTORY" \
 
 ADD bin/run-database.sh /usr/bin/
 ADD bin/utilities.sh /usr/bin/
+ADD bin/autotune /usr/local/bin/
 
 ADD test /tmp/test
 RUN bats /tmp/test

--- a/bin/autotune
+++ b/bin/autotune
@@ -34,7 +34,7 @@ def choose_chunk_size(desired_pool_size, pool_instances):
     return int(chunk_size)
 
 
-def generate_config(_mysql_version, ram_mb):
+def generate_config(mysql_version, ram_mb):
     # We assign about 80% of RAM for the InnoDB buffer pool. This is not
     # perfect, but it's a decent rule of thumb when we don't know anything
     # about the user's workload.
@@ -53,11 +53,15 @@ def generate_config(_mysql_version, ram_mb):
 
     assert final_pool_size % (pool_instances * chunk_size) == 0
 
-    return {
+    ret = {
         "innodb_buffer_pool_size": "{0}M".format(final_pool_size),
-        "innodb_buffer_pool_chunk_size": "{0}M".format(chunk_size),
-        "innodb_buffer_pool_instances": str(pool_instances)
+        "innodb_buffer_pool_instances": str(pool_instances),
     }
+
+    if mysql_version >= (5, 7):
+        ret["innodb_buffer_pool_chunk_size"] = "{0}M".format(chunk_size)
+
+    return ret
 
 
 def main():
@@ -73,6 +77,26 @@ def main():
 
 def test():
     test_cases = [
+        [(5, 6), 0.5 * 1024, {
+            "innodb_buffer_pool_size": "408M",
+            "innodb_buffer_pool_instances": "1"
+        }],
+        [(5, 6), 1024, {
+            "innodb_buffer_pool_size": "816M",
+            "innodb_buffer_pool_instances": "1"
+        }],
+        [(5, 6), 2 * 1024, {
+            "innodb_buffer_pool_size": "1632M",
+            "innodb_buffer_pool_instances": "1"
+        }],
+        [(5, 6), 4 * 1024, {
+            "innodb_buffer_pool_size": "3264M",
+            "innodb_buffer_pool_instances": "3"
+        }],
+        [(5, 6), 7 * 1024, {
+            "innodb_buffer_pool_size": "5720M",
+            "innodb_buffer_pool_instances": "5"
+        }],
         [(5, 7), 0.5 * 1024, {
             "innodb_buffer_pool_size": "408M",
             "innodb_buffer_pool_chunk_size": "204M",

--- a/bin/autotune
+++ b/bin/autotune
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+import sys
+import os
+
+
+def approximate_chunk_size(desired_pool_size, pool_instances):
+    base = desired_pool_size / pool_instances
+
+    # MySQL indicates that you'll have problems if desired_pool_size /
+    # chunk_size is greater than 1000. We're unlikely to need to go this deep,
+    # so we just stop tuning the chunk size if we're about to go to more than
+    # 250 chunks.
+    if desired_pool_size / base > 2 * 125:
+        return base
+
+    # We don't want unreasonably small chunks (and we probably have only one
+    # pool if we're dealing with super small chunks anyway), so if we're about
+    # to consider chunks smaller than 256MB, we abort here.
+    if base <= 2 * 128:
+        return base
+
+    # Our chunks are a little too big, we can iterate further.
+    return approximate_chunk_size(
+        desired_pool_size / 2, pool_instances
+    )
+
+
+def choose_chunk_size(desired_pool_size, pool_instances):
+    # This method finds a chunk size that will let us maximize our pool size
+    # considering a given number of instances, all the while satisfying the
+    # MySQL requirement that pool_size be a multiple of chunk_size *
+    # pool_instances.
+    chunk_size = approximate_chunk_size(desired_pool_size, pool_instances)
+    return int(chunk_size)
+
+
+def generate_config(_mysql_version, ram_mb):
+    # We assign about 80% of RAM for the InnoDB buffer pool. This is not
+    # perfect, but it's a decent rule of thumb when we don't know anything
+    # about the user's workload.
+    desired_pool_size = float(ram_mb * 0.8)
+
+    # We want our InnoDB pool instances to be about 1GB each.
+    pool_instances = max(int(desired_pool_size / 1024), 1)
+
+    # The pool_size must be a multiple of pool_instances * chunk_size. We
+    # choose the chunk_size to let us maximimize the pool_size, and truncate
+    # anything left over (it'll be small).
+    chunk_size = choose_chunk_size(desired_pool_size, pool_instances)
+    final_pool_size = int(desired_pool_size) - (
+        int(desired_pool_size) % (pool_instances * chunk_size)
+    )
+
+    assert final_pool_size % (pool_instances * chunk_size) == 0
+
+    return {
+        "innodb_buffer_pool_size": "{0}M".format(final_pool_size),
+        "innodb_buffer_pool_chunk_size": "{0}M".format(chunk_size),
+        "innodb_buffer_pool_instances": str(pool_instances)
+    }
+
+
+def main():
+    raw_version = os.environ['MYSQL_VERSION']
+    mysql_version = tuple(int(x) for x in raw_version.split('.'))
+    ram_mb = int(os.environ.get('APTIBLE_CONTAINER_SIZE', '1024'))
+    config = generate_config(mysql_version, ram_mb)
+
+    print("[mysqld]")
+    for k, v in sorted(config.items()):
+        print("{0} = {1}".format(k, v))
+
+
+def test():
+    test_cases = [
+        [(5, 7), 0.5 * 1024, {
+            "innodb_buffer_pool_size": "408M",
+            "innodb_buffer_pool_chunk_size": "204M",
+            "innodb_buffer_pool_instances": "1"
+        }],
+        [(5, 7), 1024, {
+            "innodb_buffer_pool_size": "816M",
+            "innodb_buffer_pool_chunk_size": "204M",
+            "innodb_buffer_pool_instances": "1"
+        }],
+        [(5, 7), 2 * 1024, {
+            "innodb_buffer_pool_size": "1632M",
+            "innodb_buffer_pool_chunk_size": "204M",
+            "innodb_buffer_pool_instances": "1"
+        }],
+        [(5, 7), 4 * 1024, {
+            "innodb_buffer_pool_size": "3264M",
+            "innodb_buffer_pool_chunk_size": "136M",
+            "innodb_buffer_pool_instances": "3"
+        }],
+        [(5, 7), 7 * 1024, {
+            "innodb_buffer_pool_size": "5720M",
+            "innodb_buffer_pool_chunk_size": "143M",
+            "innodb_buffer_pool_instances": "5"
+        }],
+    ]
+
+    for version, size, expected_config in test_cases:
+        prefix = "MySQL {0} at {1}GB".format(
+            '.'.join(str(x) for x in version), size / 1024
+        )
+
+        real_config = generate_config(version, size)
+
+        real_keys = sorted(real_config.keys())
+        expected_keys = sorted(expected_config.keys())
+
+        m = "{0}: keys differ\n  Got: {1}\n  Expected: {2}".format(
+            prefix, real_keys, expected_keys
+        )
+        assert real_keys == expected_keys, m
+
+        for key, expected in expected_config.items():
+            real = real_config[key]
+            m = "{0}: {1} differs:\n  Got: {2}\n  Expected: {3}".format(
+                prefix, key, real, expected
+            )
+            assert real == expected, m
+
+    sys.stderr.write("OK\n")
+
+
+def usage(program):
+    sys.stderr.write("Usage: {0} [--test]\n".format(program))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        main()
+    elif len(sys.argv) == 2 and sys.argv[1] == '--test':
+        test()
+    else:
+        usage(sys.argv[0])

--- a/templates/etc/mysql/conf.d/overrides.cnf.template
+++ b/templates/etc/mysql/conf.d/overrides.cnf.template
@@ -31,4 +31,9 @@ ssl-cipher = __SSL_CIPHERS__
 port = __PORT__
 
 [innodb]
+# TODO: Remove this section? [innodb] does not exist.
 innodb_flush_method=normal
+
+# TODO: innodb_log_file_size=256M Unfortunately, we can't change this in the
+# image or MySQL instances started earlier will refuse to read it. Ultimately,
+# we'll need to persist this to disk and configure it once.

--- a/templates/etc/mysql/conf.d/overrides.cnf.template
+++ b/templates/etc/mysql/conf.d/overrides.cnf.template
@@ -33,7 +33,3 @@ port = __PORT__
 [innodb]
 # TODO: Remove this section? [innodb] does not exist.
 innodb_flush_method=normal
-
-# TODO: innodb_log_file_size=256M Unfortunately, we can't change this in the
-# image or MySQL instances started earlier will refuse to read it. Ultimately,
-# we'll need to persist this to disk and configure it once.

--- a/test/autotune.bats
+++ b/test/autotune.bats
@@ -1,0 +1,5 @@
+#!/usr/bin/env bats
+
+@test "autotune should pass its self-tests" {
+  /usr/local/bin/autotune --test
+}

--- a/test/mysql-autotune.bats
+++ b/test/mysql-autotune.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
+setup() {
+  initialize_mysql
+}
+
+teardown() {
+  stop_mysql
+}
+
+@test "It should autotune for a 512MB container" {
+  APTIBLE_CONTAINER_SIZE=512 run_server
+  run-database.sh --client "mysql://root@localhost/db" -Ee "SELECT @@innodb_buffer_pool_size/1024/1024;" | grep 408
+}
+
+@test "It should autotune for a 1GB container" {
+  APTIBLE_CONTAINER_SIZE=1024 run_server
+  run-database.sh --client "mysql://root@localhost/db" \
+    -Ee "SELECT @@innodb_buffer_pool_size/1024/1024;" | grep 816
+}
+
+@test "It should autotune for a 2GB container" {
+  APTIBLE_CONTAINER_SIZE=2048 run_server
+  run-database.sh --client "mysql://root@localhost/db" \
+    -Ee "SELECT @@innodb_buffer_pool_size/1024/1024;" | grep 1632
+}
+
+@test "It should autotune for a 4GB container" {
+  APTIBLE_CONTAINER_SIZE=4096 run_server
+  run-database.sh --client "mysql://root@localhost/db" \
+    -Ee "SELECT @@innodb_buffer_pool_size/1024/1024;" | grep 3264
+}

--- a/test/mysql.bats
+++ b/test/mysql.bats
@@ -135,7 +135,6 @@ teardown() {
 }
 
 @test "It should read a config file from persistent storage." {
-
   run run-database.sh --client "mysql://root@localhost/db" -Ee "SELECT @@sql_mode;"
   [ "${lines[1]}" = "@@sql_mode: STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION" ]
 
@@ -147,4 +146,9 @@ teardown() {
 
   run run-database.sh --client "mysql://root@localhost/db" -Ee "SELECT @@sql_mode;"
   [ "${lines[1]}" = "@@sql_mode: ONLY_FULL_GROUP_BY" ]
+}
+
+@test "It should configure innodb_log_file_size" {
+  run-database.sh --client "mysql://root@localhost/db" \
+    -Ee "SELECT @@innodb_log_file_size/1024/1024;" | grep 256
 }

--- a/test/test_helper.sh
+++ b/test/test_helper.sh
@@ -27,9 +27,13 @@ initialize_mysql() {
 }
 
 run_server() {
+  # This would not be persisted from --initialize to regular start.
+  rm -rf "$CONF_DIRECTORY"
+  cp -r "$OLD_CONF_DIRECTORY" "$CONF_DIRECTORY"  # Templates are in there
+
   export LOG_FILE="/tmp/mysql.log"
   /usr/bin/run-database.sh > "$LOG_FILE" 2>&1 &
-  until mysqladmin ping; do sleep 0.1; done
+  until mysqladmin ping 2>/dev/null; do sleep 0.1; done
 }
 
 stop_server () {


### PR DESCRIPTION
commit 40a8e4e32089dcbaeafd340658e40a5ec1927a9d
Author: Thomas Orozco <thomas@orozco.fr>
Date:   Wed Nov 22 17:56:09 2017 +0100

    Bump MySQLs

commit d711b94a335b095935c628090b6a16ad4322b220
Author: Thomas Orozco <thomas@orozco.fr>
Date:   Wed Nov 22 17:54:31 2017 +0100

    Auto-configure from APTIBLE_CONTAINER_SIZE
    
    This adds support for auto-configuration of the InnoDB buffer pool based
    on the RAM size reported by Aptible in APTIBLE_CONTAINER_SIZE.
    
    I've ordered the files so that persist.cnf takes precedence over the
    autotune configuration, should they conflict. That said, note that
    considering the very peculiar rules MySQL has around the InnoDB buffer
    pool configuration, overriding just one variable in the persist.cnf file
    is likely to yield a poor configuration.

commit 70cbdcfbfd23194035372a23fd0933ced2ba8072
Author: Thomas Orozco <thomas@orozco.fr>
Date:   Wed Nov 22 18:03:44 2017 +0100

    Configure innodb_log_file_size
    
    The log file size default on MySQL is not really appropriate for any
    workload, so we turn that up a bit, from 5MB to 256MB.
    
    Note that the log file size cannot be changed after the database has
    been started, so we only configure this file when running --initialize.
    
    This is fairly costly in terms of disk space, but considering all MySQL
    databases on Enclave have 10GB of disk anyway (and our plans include a
    large amount of free disk space), it's probably what's best for our
    customers (of course, every workload would have its own sweet spot, and
    some customers are likely to need less, but this is the best we can do
    as a basic heuristic).
    
    See: https://www.percona.com/blog/2011/11/21/should-mysql-update-the-default-innodb_log_file_size/

---

cc @fancyremarker 
FYI @UserNotFound 