### PR TITLE
Test for supported protocols

### DIFF
--- a/5.6-performance-schema/test/mysql-56.bats
+++ b/5.6-performance-schema/test/mysql-56.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
+@test "It should allow connections using TLS1.0" {
+  tls_version="$(run-database.sh --client 'mysql://root@localhost/db' \
+    -Ee "SHOW SESSION STATUS LIKE 'Ssl_version';" | grep Value | awk '{ print $2 }')"
+  [[ "$tls_version" == "TLSv1" ]]
+}

--- a/5.6/test/mysql-56.bats
+++ b/5.6/test/mysql-56.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
+@test "It should allow connections using TLS1.0" {
+  tls_version="$(run-database.sh --client 'mysql://root@localhost/db' \
+    -Ee "SHOW SESSION STATUS LIKE 'Ssl_version';" | grep Value | awk '{ print $2 }')"
+  [[ "$tls_version" == "TLSv1" ]]
+}

--- a/5.7-performance-schema/test/mysql-57.bats
+++ b/5.7-performance-schema/test/mysql-57.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
+get_session_protocol() {
+  run-database.sh --client "mysql://root@localhost/db" "$@" \
+    -Ee "SHOW SESSION STATUS LIKE 'Ssl_version';" | grep Value | awk '{print $2}'
+}
+
+@test "It should be configured to allow connections using TLS1.0 and TLS1.1" {
+  tls_versions="$(run-database.sh --client 'mysql://root@localhost/db' \
+    -Ee "SHOW GLOBAL VARIABLES LIKE 'tls_version';" | grep Value | awk '{print $2}')"
+  [[ "$tls_versions" == "TLSv1,TLSv1.1" ]]
+}
+
+@test "It should allow connections using TLS1.0" {
+  tls_version="$(get_session_protocol --tls-version=TLSv1)"
+  [[ "$tls_version" == "TLSv1" ]]
+}
+
+@test "It should allow connections using TLS1.1" {
+  tls_version="$(get_session_protocol --tls-version=TLSv1.1)"
+  [[ "$tls_version" == "TLSv1.1" ]]
+}
+
+@test "It should disallow connections using TLS1.2" {
+  tls_version="$(get_session_protocol --tls-version=TLSv1.2)"
+  ! [[ "$tls_version" == "TLSv1.2" ]]
+}

--- a/5.7/test/mysql-57.bats
+++ b/5.7/test/mysql-57.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
+get_session_protocol() {
+  run-database.sh --client "mysql://root@localhost/db" "$@" \
+    -Ee "SHOW SESSION STATUS LIKE 'Ssl_version';" | grep Value | awk '{print $2}'
+}
+
+@test "It should be configured to allow connections using TLS1.0 and TLS1.1" {
+  tls_versions="$(run-database.sh --client 'mysql://root@localhost/db' \
+    -Ee "SHOW GLOBAL VARIABLES LIKE 'tls_version';" | grep Value | awk '{print $2}')"
+  [[ "$tls_versions" == "TLSv1,TLSv1.1" ]]
+}
+
+@test "It should allow connections using TLS1.0" {
+  tls_version="$(get_session_protocol --tls-version=TLSv1)"
+  [[ "$tls_version" == "TLSv1" ]]
+}
+
+@test "It should allow connections using TLS1.1" {
+  tls_version="$(get_session_protocol --tls-version=TLSv1.1)"
+  [[ "$tls_version" == "TLSv1.1" ]]
+}
+
+@test "It should disallow connections using TLS1.2" {
+  tls_version="$(get_session_protocol --tls-version=TLSv1.2)"
+  ! [[ "$tls_version" == "TLSv1.2" ]]
+}

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -38,7 +38,7 @@ ADD bin/utilities.sh /usr/bin/
 ADD bin/autotune /usr/local/bin/
 
 ADD test /tmp/test
-RUN bats /tmp/test
+ADD <%= ENV.fetch 'TAG' %>/test /tmp/test
 
 VOLUME ["$DATA_DIRECTORY"]
 EXPOSE 3306

--- a/test.sh
+++ b/test.sh
@@ -4,6 +4,10 @@ set -o nounset
 
 IMG="$REGISTRY/$REPOSITORY:$TAG"
 
+echo "Unit Tests..."
+docker run -it --rm --entrypoint "bash" "$IMG" \
+ -c "bats /tmp/test"
+
 TESTS=(
   test-log
   test-restart

--- a/test/mysql.bats
+++ b/test/mysql.bats
@@ -2,14 +2,6 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-setup() {
-  start_mysql
-}
-
-teardown() {
-  stop_mysql
-}
-
 @test "It should install MySQL $MYSQL_PACKAGE_VERSION" {
   run mysqld --version
   [[ "$output" =~ "Ver ${MYSQL_PACKAGE_VERSION%%-*}" ]]  # Package version up to -

--- a/test/test_helper.sh
+++ b/test/test_helper.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+setup() {
+  start_mysql
+}
+
+teardown() {
+  stop_mysql
+}
+
 start_mysql() {
   initialize_mysql
   run_server


### PR DESCRIPTION
The best way I found to test this was to verify the intended configuration via`SHOW GLOBAL VARIABLES LIKE 'tls_version';` though this only work on 5.7, not 5.6

We can additionally connect with a mysql client, specifying the tls version the client connections with, and inspect the session protocol via `SHOW SESSION STATUS LIKE 'Ssl_version';` -- though there is no client option in 5.6.

Additionally, it looks like MySQL 5.7 Community Edition binary distributions are compiled using yaSSL, which does not support 1.2.  It seems we have a test to ensure ours was build with OpenSSL support, so I'm not sure why 1.2 support isn't included in our image?
https://github.com/aptible/docker-mysql/blob/master/test/mysql.bats#L36-L39