### PR TITLE
Increase max packet size.

### DIFF
--- a/templates/etc/mysql/conf.d/overrides.cnf.template
+++ b/templates/etc/mysql/conf.d/overrides.cnf.template
@@ -8,7 +8,7 @@ secure-file-priv = __SCRATCH_DIRECTORY__
 skip-external-locking
 
 key_buffer_size = 16M
-max_allowed_packet = 16M
+max_allowed_packet = 64M
 thread_stack = 192K
 thread_cache_size = 8
 

--- a/test/mysql.bats
+++ b/test/mysql.bats
@@ -165,3 +165,8 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   run-database.sh --client "mysql://root@localhost/db" \
     -Ee "SHOW VARIABLES LIKE 'performance_schema';" | grep ON
 }
+
+@test "It should have max_allowed_packet set to 64mb" {
+  run-database.sh --client "mysql://root@localhost/db" \
+    -Ee "SELECT @@GLOBAL.max_allowed_packet/1024/1024;" | grep 64
+}


### PR DESCRIPTION
The MySQL default for `max_allowed_packet` is:

* 5.6 : 4mb
* 5.7 : 4mb
* 8.0 : 64mb

We had increased it to 16mb in our config (before 8.0 came out), but effectively this _decreases_ the value on 8.0 over the MySQL defaults. Increasing it here to 64mb for all versions.

____

https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet