### PR TITLE
Replication improvements.

### DIFF
--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -288,11 +288,18 @@ elif [[ "$1" == "--initialize-from" ]]; then
     GRANT REPLICATION SLAVE ON *.* TO '$MYSQL_REPLICATION_USERNAME'@'$MYSQL_REPLICATION_HOST' $grant_ssl;
   "
 
-  PRIVILEGES_DUMPFILE="${DATA_DIRECTORY}/master.dump"
-  DATA_DUMPFILE="${DATA_DIRECTORY}/db.dump"
-
   # Create slave configuration
   echo "$MYSQL_REPLICATION_SLAVE_SERVER_ID" > "${DATA_DIRECTORY}/${SERVER_ID_FILE}"
+
+
+  # Prevent writing changes to binlog during loading from dump, to avoid requiring more
+  # disk space on the replica than the exact data set we're loading.
+
+  # This is a little hacky, but the --disable-log-bin option for `mysqld` only exists for
+  # 8.0+, so we need to either set the session varible while loading data, or just
+  # change the replication configuration file (here during --initialize-from only).
+
+  sed -i '/^log-bin =/d' /etc/mysql/conf.d/replication.cnf.template
 
   mysql_initialize_innodb_log_file_size
 
@@ -304,23 +311,6 @@ elif [[ "$1" == "--initialize-from" ]]; then
   # Now, retrieve data from the master
   # Note that this will fail if binary logging is not enabled on the master (because we use --master-data, which
   # is expected to include the binary log position), which is good.
-
-  # TODO - Do we want to enable --single-transaction? This would be preferable because right now
-  # we'll acquire locks that will slow down any currently running application (which is bad).
-  # If we use --single-transaction, that won't be the case, but:
-  # - It only works properly with InnoDB tables, but MySQL won't enforce it.
-  # - There can't be any data definition operations (e.g. ALTER TABLE happening at the same time), but
-  #   MySQL won't enforce it.
-
-  # shellcheck disable=SC2154
-  MYSQL_PWD="$password" mysqldump --host "$host" --port "${port:-$DEFAULT_PORT}" --user "$MYSQL_REPLICATION_ROOT" --ssl-mode=REQUIRED --ssl-cipher="${SSL_CIPHERS}" \
-    mysql --flush-privileges \
-    > "${PRIVILEGES_DUMPFILE}"
-
-   # shellcheck disable=SC2154
-  MYSQL_PWD="$password" mysqldump --host "$host" --port "${port:-$DEFAULT_PORT}" --user "$MYSQL_REPLICATION_ROOT" --ssl-mode=REQUIRED --ssl-cipher="${SSL_CIPHERS}" \
-    --master-data --all-databases \
-    > "${DATA_DUMPFILE}"
 
   # Launch MySQL, load the data in, then start the slave.
   # The slave will restart automatically next time MySQL starts up.
@@ -340,13 +330,13 @@ elif [[ "$1" == "--initialize-from" ]]; then
     MASTER_SSL_CIPHER = '${SSL_CIPHERS}';"
 
   # Load initial data and log position
-  mysql mysql < "${PRIVILEGES_DUMPFILE}"
-  mysql < "${DATA_DUMPFILE}"
+  MYSQL_PWD="$password" mysqldump --host "$host" --port "${port:-$DEFAULT_PORT}" --user "$MYSQL_REPLICATION_ROOT" --ssl-mode=REQUIRED --ssl-cipher="${SSL_CIPHERS}" \
+    mysql --flush-privileges |  mysql mysql
+  # shellcheck disable=SC2154
+  MYSQL_PWD="$password" mysqldump --host "$host" --port "${port:-$DEFAULT_PORT}" --user "$MYSQL_REPLICATION_ROOT" --ssl-mode=REQUIRED --ssl-cipher="${SSL_CIPHERS}" \
+    --master-data --all-databases --single-transaction | mysql
 
   mysql_shutdown
-
-  # Cleanup
-  rm "${PRIVILEGES_DUMPFILE}" "${DATA_DUMPFILE}"
 
 elif [[ "$1" == "--client" ]]; then
   [ -z "$2" ] && echo "docker run -it aptible/mysql --client mysql://..." && exit

--- a/templates/etc/mysql/conf.d/replication.cnf.template
+++ b/templates/etc/mysql/conf.d/replication.cnf.template
@@ -13,6 +13,9 @@ log-bin = mysql-bin
 # hurt to have the option here.
 relay-log = mysql-relay
 
+# Ensure chained replication works
+log-slave-updates = on
+
 # Ensure the binlog data is consistent on disk. If we run out of space or crash
 # uncleanly, this will be helpful. Naturally, this will impact performance, but
 # it's the price we pay for not losing data, and it's actually the default as

--- a/test-replication.sh
+++ b/test-replication.sh
@@ -72,7 +72,7 @@ docker run -it --rm \
   --volumes-from "$SLAVE_DATA_CONTAINER" \
   "$IMG" --initialize-from "$MASTER_USER_URL"   # Use the user URL, but --initialize-from will use root instead
 
-echo "No binlog file on the replica contains statemnts loaded from the dump"
+echo "No binlog file on the replica contains statements loaded from the dump"
 # MySQL 5.6 / 5.7 compatibility
 if [[ "$MYSQL_VERSION" = "5.6" ]]; then
   BINGLOG_INDEX="000003"


### PR DESCRIPTION
The motivations here are to improve MySQL replication process to be less impactful and more predictable.   This comes down to a couple of key changes:

*  Use the [--single-transaction](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_single-transaction) option of `mysqldump` to avoid generated a read-lock on the master for the duration of replication.
* Don't use an intermediate file when transferring, to avoid the replica needing to have a bigger disk (ex 2x the data size)
* Don't write binlog when loading from the dump, to avoid the binlog taking extra space (eg ~2x, since it'd record every write)
* Enable relay-log in 5.6 and 5.7 (it's defaulted to ON already in 8.0) so that you can chain replicas off of other replicas
* Being more explicit in our documentation for MySQL about the process used, implications for performance, and potential drawbacks